### PR TITLE
Scala 2.11 support removed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 lazy val scala212 = "2.12.11"
-lazy val scala211 = "2.11.12"
-lazy val supportedScalaVersions = List(scala212, scala211)
+lazy val supportedScalaVersions = List(scala212)
 
 val sparkVersion = "3.0.0"
 val sparkTestVersion = "2.4.5"
@@ -10,7 +9,7 @@ val dependencies = Seq(
   "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
   "org.apache.spark" %% "spark-hive" % sparkVersion % Provided,
   "org.apache.spark" %% "spark-avro" % sparkVersion % Provided,
-  "io.delta" %% "delta-core" % "0.7.0" % Provided,
+  "io.delta" %% "delta-core" % "0.6.0" % Provided,
   "com.typesafe" % "config" % "1.3.2")
 
 val testDependencies = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val dependencies = Seq(
   "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
   "org.apache.spark" %% "spark-hive" % sparkVersion % Provided,
   "org.apache.spark" %% "spark-avro" % sparkVersion % Provided,
-  "io.delta" %% "delta-core" % "0.6.0" % Provided,
+  "io.delta" %% "delta-core" % "0.7.0" % Provided,
   "com.typesafe" % "config" % "1.3.2")
 
 val testDependencies = Seq(


### PR DESCRIPTION
The build.sbt mentions support for Scala version 2.11.12.

However, due to Spark 3.0.0's reliance on Scala 2.12, the project is effectively incompatible with Scala 2.11.12. Running sbt +compile fails due to this discrepancy, although it hasn't caused issues as the library has only been published using Scala 2.12.

This PR removes the support for Scala 2.11.